### PR TITLE
Removed 'Add Parent' button in child dashboard

### DIFF
--- a/client/src/child/Dashboard.js
+++ b/client/src/child/Dashboard.js
@@ -10,8 +10,7 @@ const Dashboard = ({ user }) => (
   <CheckUser user={user} userRole="child">
     <Navbar />
     <h1>Welcome, {user.username}</h1>
-    <button style={styles.addButton}>Add Parent</button>
-
+    
     <div style={styles.container}>
 
       <div style={styles.row1}>


### PR DESCRIPTION
When the parent adds the child, it automatically ties them together so the child doesn't add the parent.